### PR TITLE
Remove Experience from RequiredSkills in Position model (Cu 86c11awdc)

### DIFF
--- a/src/main/java/com/example/b2b_opportunities/Dto/Request/RequiredSkillsDto.java
+++ b/src/main/java/com/example/b2b_opportunities/Dto/Request/RequiredSkillsDto.java
@@ -11,5 +11,5 @@ public class RequiredSkillsDto {
     @NotNull
     private Long skillId;
     @Valid
-    private ExperienceRequestDto experience;
+    private Integer months;
 }

--- a/src/main/java/com/example/b2b_opportunities/Dto/Response/RequiredSkillResponseDto.java
+++ b/src/main/java/com/example/b2b_opportunities/Dto/Response/RequiredSkillResponseDto.java
@@ -15,5 +15,5 @@ import lombok.Setter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RequiredSkillResponseDto {
     private Long skillId;
-    private ExperienceResponseDto experience;
+    private Integer months;
 }

--- a/src/main/java/com/example/b2b_opportunities/Entity/RequiredSkill.java
+++ b/src/main/java/com/example/b2b_opportunities/Entity/RequiredSkill.java
@@ -33,7 +33,6 @@ public class RequiredSkill {
     @JoinColumn(name = "skill_id")
     private Skill skill;
 
-    @ManyToOne
-    @JoinColumn(name = "experience_id", nullable = true)
-    private Experience experience;
+    @JoinColumn(name = "months")
+    private Integer months;
 }

--- a/src/main/java/com/example/b2b_opportunities/Mapper/RequiredSkillMapper.java
+++ b/src/main/java/com/example/b2b_opportunities/Mapper/RequiredSkillMapper.java
@@ -16,11 +16,11 @@ public class RequiredSkillMapper {
             dto.setSkillId(s.getSkill().getId());
 
             // Set Experience
-            if (s.getExperience() != null) {
+            if (s.getMonths() != null) {
                 ExperienceResponseDto experienceResponseDto = new ExperienceResponseDto();
-                Integer months = s.getExperience().getMonths();
-                    if (months != null) experienceResponseDto.setMonths(months);
-                    dto.setExperience(experienceResponseDto);
+                Integer months = s.getMonths();
+                if (months != null) experienceResponseDto.setMonths(months);
+                dto.setMonths(experienceResponseDto.getMonths());
             }
             return dto;
         }).collect(Collectors.toList());

--- a/src/main/java/com/example/b2b_opportunities/Service/PositionService.java
+++ b/src/main/java/com/example/b2b_opportunities/Service/PositionService.java
@@ -1,5 +1,6 @@
 package com.example.b2b_opportunities.Service;
 
+import com.example.b2b_opportunities.Dto.Request.ExperienceRequestDto;
 import com.example.b2b_opportunities.Dto.Request.PositionRequestDto;
 import com.example.b2b_opportunities.Dto.Request.RateRequestDto;
 import com.example.b2b_opportunities.Dto.Request.RequiredSkillsDto;
@@ -273,9 +274,14 @@ public class PositionService {
         RequiredSkill requiredSkillResult = new RequiredSkill();
         requiredSkillResult.setPosition(position);
         requiredSkillResult.setSkill(skill);
-        if (requiredSkill.getExperience() != null) {
-            Experience experience = experienceRepository.save(ExperienceMapper.toExperience(requiredSkill.getExperience()));
-            requiredSkillResult.setExperience(experience);
+        if (requiredSkill.getMonths() != null) {
+            ExperienceRequestDto experienceDto = new ExperienceRequestDto();
+            experienceDto.setMonths(requiredSkill.getMonths());
+
+            Experience experience = ExperienceMapper.toExperience(experienceDto);
+            experienceRepository.save(experience);
+
+            requiredSkillResult.setMonths(experience.getMonths());
         }
         return requiredSkillResult;
     }

--- a/src/main/resources/db/changelog/37-alter-required-skill-add-months-column.sql
+++ b/src/main/resources/db/changelog/37-alter-required-skill-add-months-column.sql
@@ -1,0 +1,10 @@
+ALTER TABLE required_skill
+ADD COLUMN months INTEGER;
+
+UPDATE required_skill rs
+SET months = e.months
+FROM experience e
+WHERE rs.experience_id = e.id;
+
+ALTER TABLE required_skill
+DROP COLUMN experience_id;

--- a/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/src/main/resources/db/changelog/db.changelog-master.yml
@@ -107,3 +107,6 @@ databaseChangeLog:
   - include:
       file: 36-fix-id-sequences.sql
       relativeToChangelogFile: true
+  - include:
+      file: 37-alter-required-skill-add-months-column.sql
+      relativeToChangelogFile: true

--- a/src/test/java/com/example/b2b_opportunities/Controller/PositionControllerTest.java
+++ b/src/test/java/com/example/b2b_opportunities/Controller/PositionControllerTest.java
@@ -1,6 +1,5 @@
 package com.example.b2b_opportunities.Controller;
 
-import com.example.b2b_opportunities.Dto.Request.ExperienceRequestDto;
 import com.example.b2b_opportunities.Dto.Request.PositionRequestDto;
 import com.example.b2b_opportunities.Dto.Request.RateRequestDto;
 import com.example.b2b_opportunities.Dto.Request.RequiredSkillsDto;
@@ -228,9 +227,7 @@ class PositionControllerTest {
         requiredSkillsDto.setSkillId(testSkill.getId());
 
         // Create a valid ExperienceRequestDto for Skills(not required)
-        ExperienceRequestDto experienceRequestDto = new ExperienceRequestDto();
-        experienceRequestDto.setMonths(6);
-        requiredSkillsDto.setExperience(experienceRequestDto);
+        requiredSkillsDto.setMonths(6);
         requestDto.setRequiredSkills(List.of(requiredSkillsDto));
 
         requestDto.setOptionalSkills(List.of(6L, 7L));
@@ -254,7 +251,9 @@ class PositionControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.description").value("Position for software engineer"))
                 .andExpect(jsonPath("$.statusId").value(1))
-                .andExpect(jsonPath("$.location").value(location.getId()));
+                .andExpect(jsonPath("$.location").value(location.getId()))
+                .andExpect(jsonPath("$.requiredSkills[0].skillId").value(testSkill.getId()))
+                .andExpect(jsonPath("$.requiredSkills[0].months").value(6));
 
         List<Position> positions = positionRepository.findAll();
         assertThat(positions).hasSize(1);
@@ -308,7 +307,7 @@ class PositionControllerTest {
                 .andExpect(jsonPath("$[0].rate").value(hasEntry("max", 100)))
                 .andExpect(jsonPath("$[0].rate").value(hasEntry("currencyId", currency.getId().intValue())))
                 .andExpect(jsonPath("$[0].requiredSkills[0].skillId").value(testSkill.getId()))
-                .andExpect(jsonPath("$[0].requiredSkills[0].experience.months").value(6))
+                .andExpect(jsonPath("$[0].requiredSkills[0].months").value(6))
                 .andExpect(jsonPath("$[0].minYearsExperience").value(2))
                 .andExpect(jsonPath("$[0].hoursPerWeek").value(40))
                 .andExpect(jsonPath("$[0].responsibilities").value(containsInAnyOrder("Develop software", "Review code")))
@@ -331,7 +330,7 @@ class PositionControllerTest {
                 .andExpect(jsonPath("$.rate").value(hasEntry("max", 100)))
                 .andExpect(jsonPath("$.rate").value(hasEntry("currencyId", currency.getId().intValue())))
                 .andExpect(jsonPath("$.requiredSkills[0].skillId").value(testSkill.getId()))
-                .andExpect(jsonPath("$.requiredSkills[0].experience.months").value(6))
+                .andExpect(jsonPath("$.requiredSkills[0].months").value(6))
                 .andExpect(jsonPath("$.minYearsExperience").value(2))
                 .andExpect(jsonPath("$.hoursPerWeek").value(40))
                 .andExpect(jsonPath("$.responsibilities").value(containsInAnyOrder("Develop software", "Review code")))
@@ -362,7 +361,7 @@ class PositionControllerTest {
                 .andExpect(jsonPath("$.rate").value(hasEntry("max", 100)))
                 .andExpect(jsonPath("$.rate").value(hasEntry("currencyId", currency.getId().intValue())))
                 .andExpect(jsonPath("$.requiredSkills[0].skillId").value(testSkill.getId()))
-                .andExpect(jsonPath("$.requiredSkills[0].experience.months").value(6))
+                .andExpect(jsonPath("$.requiredSkills[0].months").value(6))
                 .andExpect(jsonPath("$.minYearsExperience").value(2))
                 .andExpect(jsonPath("$.hoursPerWeek").value(20))
                 .andExpect(jsonPath("$.responsibilities").value(containsInAnyOrder("Develop software", "Review code")))
@@ -468,7 +467,7 @@ class PositionControllerTest {
                 .andExpect(jsonPath("$.rate").value(hasEntry("max", 100)))
                 .andExpect(jsonPath("$.rate").value(hasEntry("currencyId", currency.getId().intValue())))
                 .andExpect(jsonPath("$.requiredSkills[0].skillId").value(testSkill.getId()))
-                .andExpect(jsonPath("$.requiredSkills[0].experience.months").value(6))
+                .andExpect(jsonPath("$.requiredSkills[0].months").value(6))
                 .andExpect(jsonPath("$.minYearsExperience").value(2))
                 .andExpect(jsonPath("$.hoursPerWeek").value(40))
                 .andExpect(jsonPath("$.responsibilities").value(containsInAnyOrder("Develop software", "Review code")))

--- a/src/test/java/com/example/b2b_opportunities/Controller/SkillControllerTest.java
+++ b/src/test/java/com/example/b2b_opportunities/Controller/SkillControllerTest.java
@@ -1,6 +1,5 @@
 package com.example.b2b_opportunities.Controller;
 
-import com.example.b2b_opportunities.Entity.RequiredSkill;
 import com.example.b2b_opportunities.Entity.Skill;
 import com.example.b2b_opportunities.Repository.RequiredSkillRepository;
 import com.example.b2b_opportunities.Repository.SkillRepository;


### PR DESCRIPTION
- Change  ExperienceRequestDto experience to Integer months in RequiredSkillsDto.java class, in RequiredSkillResponseDto.java class and in RequiredSkill.java class
- Rework the getRequiredSkill method in PositionService.java class 
- Remove unused RequiredSkill import in the SkillControllerTest 
- Rework PositionControllerTest.java class (removed ExperienceRequestDto, and use requiredSkillsdto directly) 
- Add 37-alter-required-skill-add-months-column.sql file for migration (this migration adds a months column to required_skill table, removes the experience_id column) 
- include the .sql file in db.changelog-master.yml file.